### PR TITLE
Change recommended directive order

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ request_id [<matcher>] [<header>] {
 ```
 # Required to use in top-level blocks
 {
-  order request_id before respond
+  order request_id before handle
 }
 
 localhost {


### PR DESCRIPTION
Since `handle` and `route` can contain directives that write responses, I think it's best to have it ordered before `handle` to avoid issues, as per https://caddyserver.com/docs/caddyfile/directives#directive-order